### PR TITLE
from Vec to slices for API + fix test_coin stack size

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -102,15 +102,17 @@ impl CoinGeckoClient {
     ///     client.price(&["bitcoin", "ethereum"], &["usd"], true, true, true, true).await;
     /// }
     /// ```
-    pub async fn price(
+    pub async fn price<T: AsRef<str>>(
         &self,
-        ids: &[&str],
-        vs_currencies: &[&str],
+        ids: &[T],
+        vs_currencies: &[T],
         include_market_cap: bool,
         include_24hr_vol: bool,
         include_24hr_change: bool,
         include_last_updated_at: bool,
     ) -> Result<HashMap<String, Price>, Error> {
+        let ids = ids.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+        let vs_currencies = vs_currencies.iter().map(AsRef::as_ref).collect::<Vec<_>>();
         let req = format!("/simple/price?ids={}&vs_currencies={}&include_market_cap={}&include_24hr_vol={}&include_24hr_change={}&include_last_updated_at={}", ids.join("%2C"), vs_currencies.join("%2C"), include_market_cap, include_24hr_vol, include_24hr_change, include_last_updated_at);
         self.get(&req).await
     }
@@ -137,16 +139,21 @@ impl CoinGeckoClient {
     ///     ).await;
     /// }
     /// ```
-    pub async fn token_price(
+    pub async fn token_price<T: AsRef<str>>(
         &self,
         id: &str,
-        contract_addresses: &[&str],
-        vs_currencies: &[&str],
+        contract_addresses: &[T],
+        vs_currencies: &[T],
         include_market_cap: bool,
         include_24hr_vol: bool,
         include_24hr_change: bool,
         include_last_updated_at: bool,
     ) -> Result<HashMap<String, Price>, Error> {
+        let contract_addresses = contract_addresses
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>();
+        let vs_currencies = vs_currencies.iter().map(AsRef::as_ref).collect::<Vec<_>>();
         let req = format!("/simple/token_price/{}?contract_addresses={}&vs_currencies={}&include_market_cap={}&include_24hr_vol={}&include_24hr_change={}&include_last_updated_at={}", id, contract_addresses.join("%2C"), vs_currencies.join("%2C"), include_market_cap, include_24hr_vol, include_24hr_change, include_last_updated_at);
         self.get(&req).await
     }
@@ -222,10 +229,10 @@ impl CoinGeckoClient {
     ///     ).await;
     /// }
     /// ```
-    pub async fn coins_markets(
+    pub async fn coins_markets<T: AsRef<str>>(
         &self,
         vs_currency: &str,
-        ids: &[&str],
+        ids: &[T],
         category: Option<&str>,
         order: MarketsOrder,
         per_page: i64,
@@ -233,6 +240,8 @@ impl CoinGeckoClient {
         sparkline: bool,
         price_change_percentage: &[PriceChangePercentage],
     ) -> Result<Vec<CoinsMarketItem>, Error> {
+        let ids = ids.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+
         let category = match category {
             Some(c) => format!("&category={}", c),
             _ => String::from(""),
@@ -319,13 +328,13 @@ impl CoinGeckoClient {
     ///     use coingecko_rs::{params::TickersOrder, CoinGeckoClient};
     ///     let client = CoinGeckoClient::default();
     ///
-    ///     client.coin_tickers("bitcoin", None, true, 1, TickersOrder::VolumeDesc, true).await;
+    ///     client.coin_tickers::<&str>("bitcoin", None, true, 1, TickersOrder::VolumeDesc, true).await;
     /// }
     /// ```
-    pub async fn coin_tickers(
+    pub async fn coin_tickers<T: AsRef<str>>(
         &self,
         id: &str,
-        exchange_ids: Option<&[&str]>,
+        exchange_ids: Option<&[T]>,
         include_exchange_logo: bool,
         page: i64,
         order: TickersOrder,
@@ -338,8 +347,14 @@ impl CoinGeckoClient {
         };
 
         let req = match exchange_ids {
-            Some(e_ids) => format!("/coins/{}/tickers?exchange_ids={}&include_exchange_logo={}&page={}&order={}&depth={}", id, e_ids.join("%2C"), include_exchange_logo, &page, order, depth),
-            None => format!("/coins/{}/tickers?include_exchange_logo={}&page={}&order={}&depth={}", id, include_exchange_logo, &page, order, depth),
+            Some(e_ids) => {
+                let e_ids = e_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+                format!("/coins/{}/tickers?exchange_ids={}&include_exchange_logo={}&page={}&order={}&depth={}", id, e_ids.join("%2C"), include_exchange_logo, &page, order, depth)
+            }
+            None => format!(
+                "/coins/{}/tickers?include_exchange_logo={}&page={}&order={}&depth={}",
+                id, include_exchange_logo, &page, order, depth
+            ),
         };
 
         self.get(&req).await
@@ -728,10 +743,10 @@ impl CoinGeckoClient {
     ///     client.exchange_tickers("binance", Some(&["btc"]), true, 1, TickersOrder::TrustScoreAsc, true).await;
     /// }
     /// ```
-    pub async fn exchange_tickers(
+    pub async fn exchange_tickers<T: AsRef<str>>(
         &self,
         id: &str,
-        coin_ids: Option<&[&str]>,
+        coin_ids: Option<&[T]>,
         include_exchange_logo: bool,
         page: i64,
         order: TickersOrder,
@@ -744,8 +759,14 @@ impl CoinGeckoClient {
         };
 
         let req = match coin_ids {
-           Some(c_ids) => format!("/exchanges/{}/tickers?coin_ids={}&include_exchange_logo={}&page={}&order={}&depth={}", id, c_ids.join("%2C"), include_exchange_logo, &page, order, depth),
-            None => format!("/exchanges/{}/tickers?include_exchange_logo={}&page={}&order={}&depth={}", id, include_exchange_logo, &page, order, depth),
+            Some(c_ids) => {
+                let c_ids = c_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+                format!("/exchanges/{}/tickers?coin_ids={}&include_exchange_logo={}&page={}&order={}&depth={}", id, c_ids.join("%2C"), include_exchange_logo, &page, order, depth)
+            }
+            None => format!(
+                "/exchanges/{}/tickers?include_exchange_logo={}&page={}&order={}&depth={}",
+                id, include_exchange_logo, &page, order, depth
+            ),
         };
 
         self.get(&req).await

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,10 +102,10 @@ impl CoinGeckoClient {
     ///     client.price(&["bitcoin", "ethereum"], &["usd"], true, true, true, true).await;
     /// }
     /// ```
-    pub async fn price<T: AsRef<str>>(
+    pub async fn price<Id: AsRef<str>, Curr: AsRef<str>>(
         &self,
-        ids: &[T],
-        vs_currencies: &[T],
+        ids: &[Id],
+        vs_currencies: &[Curr],
         include_market_cap: bool,
         include_24hr_vol: bool,
         include_24hr_change: bool,
@@ -139,11 +139,11 @@ impl CoinGeckoClient {
     ///     ).await;
     /// }
     /// ```
-    pub async fn token_price<T: AsRef<str>>(
+    pub async fn token_price<Addr: AsRef<str>, Curr: AsRef<str>>(
         &self,
         id: &str,
-        contract_addresses: &[T],
-        vs_currencies: &[T],
+        contract_addresses: &[Addr],
+        vs_currencies: &[Curr],
         include_market_cap: bool,
         include_24hr_vol: bool,
         include_24hr_change: bool,
@@ -229,10 +229,10 @@ impl CoinGeckoClient {
     ///     ).await;
     /// }
     /// ```
-    pub async fn coins_markets<T: AsRef<str>>(
+    pub async fn coins_markets<Id: AsRef<str>>(
         &self,
         vs_currency: &str,
-        ids: &[T],
+        ids: &[Id],
         category: Option<&str>,
         order: MarketsOrder,
         per_page: i64,
@@ -331,10 +331,10 @@ impl CoinGeckoClient {
     ///     client.coin_tickers::<&str>("bitcoin", None, true, 1, TickersOrder::VolumeDesc, true).await;
     /// }
     /// ```
-    pub async fn coin_tickers<T: AsRef<str>>(
+    pub async fn coin_tickers<Ex: AsRef<str>>(
         &self,
         id: &str,
-        exchange_ids: Option<&[T]>,
+        exchange_ids: Option<&[Ex]>,
         include_exchange_logo: bool,
         page: i64,
         order: TickersOrder,
@@ -743,10 +743,10 @@ impl CoinGeckoClient {
     ///     client.exchange_tickers("binance", Some(&["btc"]), true, 1, TickersOrder::TrustScoreAsc, true).await;
     /// }
     /// ```
-    pub async fn exchange_tickers<T: AsRef<str>>(
+    pub async fn exchange_tickers<CoinId: AsRef<str>>(
         &self,
         id: &str,
-        coin_ids: Option<&[T]>,
+        coin_ids: Option<&[CoinId]>,
         include_exchange_logo: bool,
         page: i64,
         order: TickersOrder,

--- a/src/client.rs
+++ b/src/client.rs
@@ -99,13 +99,13 @@ impl CoinGeckoClient {
     ///     use coingecko_rs::CoinGeckoClient;
     ///     let client = CoinGeckoClient::default();
     ///
-    ///     client.price(vec!["bitcoin", "ethereum"], vec!["usd"], true, true, true, true).await;
+    ///     client.price(&["bitcoin", "ethereum"], &["usd"], true, true, true, true).await;
     /// }
     /// ```
     pub async fn price(
         &self,
-        ids: Vec<&str>,
-        vs_currencies: Vec<&str>,
+        ids: &[&str],
+        vs_currencies: &[&str],
         include_market_cap: bool,
         include_24hr_vol: bool,
         include_24hr_change: bool,
@@ -128,8 +128,8 @@ impl CoinGeckoClient {
     ///
     ///     client.token_price(
     ///         "ethereum",
-    ///         vec![&uniswap_contract],
-    ///         vec!["usd"],
+    ///         &[uniswap_contract],
+    ///         &["usd"],
     ///         true,
     ///         true,
     ///         true,
@@ -140,8 +140,8 @@ impl CoinGeckoClient {
     pub async fn token_price(
         &self,
         id: &str,
-        contract_addresses: Vec<&str>,
-        vs_currencies: Vec<&str>,
+        contract_addresses: &[&str],
+        vs_currencies: &[&str],
         include_market_cap: bool,
         include_24hr_vol: bool,
         include_24hr_change: bool,
@@ -205,13 +205,13 @@ impl CoinGeckoClient {
     ///     
     ///     client.coins_markets(
     ///         "usd",
-    ///         vec!["bitcoin"],
+    ///         &["bitcoin"],
     ///         None,
     ///         MarketsOrder::GeckoDesc,
     ///         1,
     ///         0,
     ///         true,
-    ///         vec![
+    ///         &[
     ///             PriceChangePercentage::OneHour,
     ///             PriceChangePercentage::TwentyFourHours,
     ///             PriceChangePercentage::SevenDays,
@@ -225,13 +225,13 @@ impl CoinGeckoClient {
     pub async fn coins_markets(
         &self,
         vs_currency: &str,
-        ids: Vec<&str>,
+        ids: &[&str],
         category: Option<&str>,
         order: MarketsOrder,
         per_page: i64,
         page: i64,
         sparkline: bool,
-        price_change_percentage: Vec<PriceChangePercentage>,
+        price_change_percentage: &[PriceChangePercentage],
     ) -> Result<Vec<CoinsMarketItem>, Error> {
         let category = match category {
             Some(c) => format!("&category={}", c),
@@ -325,7 +325,7 @@ impl CoinGeckoClient {
     pub async fn coin_tickers(
         &self,
         id: &str,
-        exchange_ids: Option<Vec<&str>>,
+        exchange_ids: Option<&[&str]>,
         include_exchange_logo: bool,
         page: i64,
         order: TickersOrder,
@@ -725,13 +725,13 @@ impl CoinGeckoClient {
     ///     use coingecko_rs::{params::TickersOrder, CoinGeckoClient};
     ///     let client = CoinGeckoClient::default();
     ///
-    ///     client.exchange_tickers("binance", Some(vec!["btc"]), true, 1, TickersOrder::TrustScoreAsc, true).await;
+    ///     client.exchange_tickers("binance", Some(&["btc"]), true, 1, TickersOrder::TrustScoreAsc, true).await;
     /// }
     /// ```
     pub async fn exchange_tickers(
         &self,
         id: &str,
-        coin_ids: Option<Vec<&str>>,
+        coin_ids: Option<&[&str]>,
         include_exchange_logo: bool,
         page: i64,
         order: TickersOrder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod tests {
         let uniswap_contract = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984";
         let res = aw!(client.token_price(
             "ethereum",
-            &[&uniswap_contract],
+            &[uniswap_contract],
             &["usd"],
             true,
             true,
@@ -182,7 +182,7 @@ mod tests {
 
         let res2 = aw!(client.coins_markets(
             "usd",
-            &[],
+            &[] as &[&str],
             None,
             MarketsOrder::MarketCapDesc,
             250,
@@ -217,14 +217,21 @@ mod tests {
     fn coin_tickers() {
         let client: CoinGeckoClient = CoinGeckoClient::default();
 
-        let res1 =
-            aw!(client.coin_tickers("bitcoin", None, true, 1, TickersOrder::VolumeDesc, true));
+        let res1 = aw!(client.coin_tickers::<&str>(
+            "bitcoin",
+            None,
+            true,
+            1,
+            TickersOrder::VolumeDesc,
+            true
+        ));
 
         assert!(res1.is_ok(), "tickers without filter should resolve");
 
         let res2 = aw!(client.coin_tickers(
             "bitcoin",
-            Some(&["binance"]),
+            #[allow(clippy::useless_vec)]
+            Some(&vec![String::from("binance")]), // &Vec<String> should also work
             true,
             1,
             TickersOrder::VolumeDesc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
         let client: CoinGeckoClient = CoinGeckoClient::default();
         let res = aw!(client.coins_list(true));
         assert!(res.is_ok(), "list should resolve");
-        assert!(res.unwrap().len() > 0, "should return at least one coin");
+        assert!(!res.unwrap().is_empty(), "should return at least one coin");
     }
 
     #[test]

--- a/src/response/simple.rs
+++ b/src/response/simple.rs
@@ -373,7 +373,7 @@ pub struct Price {
     pub sats24_h_vol: Option<f64>,
     #[serde(rename = "sats_24h_change")]
     pub sats24_h_change: Option<f64>,
-    pub last_updated_at: Option<f64>,
+    pub last_updated_at: Option<u64>,
 }
 
 // ---------------------------------------------


### PR DESCRIPTION
Hi there,

I'm using your crate on a toy project and I found the `Vec<&str>` painful to deal with when really just slices of `&str` would be enough.

Also fixed the `test_coin` that had a huge response leading to Tokio's runtime call stack to overflow.