### PR TITLE
chore: move to coingecko crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "coingecko-rs"
+name = "coingecko"
 version = "1.0.0"
 authors = ["ecklf <ecklf@icloud.com>"]
 description = "Rust library for the CoinGecko V3 API"
 documentation = "https://docs.rs/coingecko"
 repository = "https://github.com/ecklf/coingecko-rs"
-keywords = ["coingecko", "api"]
+keywords = ["coingecko", "api", "cryptocurrency"]
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# coingecko-rs
+# coingecko
 
-Rust library for the CoinGecko V3 API
+Rust library for the CoinGecko V3 API (formerly known as `coingecko-rs` crate)
 
 <p align="center">
     <img height="auto" width="300px" src="logo.png" />
@@ -12,7 +12,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-coingecko-rs = "1.0.0"
+coingecko = "1.0.0"
 ```
 
 ## Features
@@ -24,4 +24,4 @@ coingecko-rs = "1.0.0"
 
 ## Documentation
 
-[docs.rs](https://docs.rs/coingecko-rs)
+[docs.rs](https://docs.rs/coingecko)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! coingecko-rs = "1.0.0"
+//! coingecko = "1.0.0"
 //! ```
 
 /// Client module


### PR DESCRIPTION
This PR moves `coingecko-rs` to `coingecko` on crates.io

Closes #3