### PR TITLE
Upgrade chrono version 0.4.19 -> 0.4.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.6.0", features = ["full"] }
 reqwest = { version = "0.11.3", features = ["json"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
-chrono = "0.4.19"
+chrono = "0.4.22"
 
 [dev-dependencies]
 tokio-test = "0.4.2"


### PR DESCRIPTION
Because of the Potential segfault in `localtime_r` invocations in the chrono version 0.4.19 im proposing to update to a newer version.